### PR TITLE
Fixed bug in building GetAADToken in Release mode

### DIFF
--- a/GetAADToken/GetAADToken.csproj
+++ b/GetAADToken/GetAADToken.csproj
@@ -27,7 +27,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\vcnet\x64\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
GetAADToken was not building in the right location in Release mode.